### PR TITLE
Fixed typo with shebang.

### DIFF
--- a/PINCE.py
+++ b/PINCE.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# !/usr/bin/env python3
 """
 Copyright (C) 2016 Korcan Karaokçu <korcankaraokcu@gmail.com>
 Copyright (C) 2016 Çağrı Ulaş <cagriulas@gmail.com>


### PR DESCRIPTION
This is a really small change, but was causing some issues with the AUR package. The shebang needs to be on the first line or the program loader will just ignore it.