### PR TITLE
install.sh: Detect OS and add SUSE support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
 
 install: pip install psutil pexpect distorm3
 
-script: sudo ~/virtualenv/python3.4/bin/python run_tests.py -c /bin/ls
+script: sudo ~/virtualenv/python3.4/bin/python run_tests.py -c /bin/cat

--- a/install.sh
+++ b/install.sh
@@ -15,13 +15,28 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '
+OS_NAME="Debian"
+PKG_MGR="apt-get"
+PKG_NAMES_ALL="python3-setuptools python3-pip"
+PKG_NAMES_DEBIAN="$PKG_NAMES_ALL python3-pyqt5"
+PKG_NAMES_SUSE="$PKG_NAMES_ALL python3-qt5"
+PKG_NAMES="$PKG_NAMES_DEBIAN"
+PKG_NAMES_PIP="psutil pexpect distorm3"
 
-sudo apt-get install python3-setuptools
-sudo apt-get install python3-pip
-sudo apt-get install python3-pyqt5
-sudo pip3 install psutil
-sudo pip3 install pexpect
-sudo pip3 install distorm3
+LSB_RELEASE="`which lsb_release`"
+if [ -n "$LSB_RELEASE" ] ; then
+    OS_NAME="`$LSB_RELEASE -d -s`"
+fi
+
+case "$OS_NAME" in
+*SUSE*)
+    PKG_MGR="zypper"
+    PKG_NAMES="$PKG_NAMES_SUSE"
+    ;;
+esac
+
+sudo $PKG_MGR install $PKG_NAMES
+sudo pip3 install $PKG_NAMES_PIP
 
 if [ -e libPINCE/gdb_pince/gdb-7.11.1/bin/gdb ] ; then
     echo "GDB has been already compiled&installed, recompile&install? (y/n)"


### PR DESCRIPTION
It is not required to call the package manager multiple times. It is enough to call it once with all packages. Do that to reduce code duplication.

To support other distros which are not using `apt-get`, use `lsb_release -d -s` to get the distribution name from `/etc/os-release`. Then check if it contains "SUSE" and use `zypper` + the SUSE package names in this case. But still default to a Debian release.