### PR TITLE
Fix create process

### DIFF
--- a/PINCE.py
+++ b/PINCE.py
@@ -903,6 +903,7 @@ class ProcessForm(QMainWindow, ProcessWindow):
             if GDB_Engine.create_process(file_path, args, ld_preload_path, gdb_path):
                 p = SysUtils.get_process_information(GDB_Engine.currentpid)
                 self.parent().label_SelectedProcess.setText(str(p.pid) + " - " + p.name())
+                self.parent().on_status_stopped()
                 self.enable_scan_gui()
                 self.close()
             else:

--- a/libPINCE/GDB_Engine.py
+++ b/libPINCE/GDB_Engine.py
@@ -574,6 +574,10 @@ def create_process(process_path, args="", ld_preload_path="", additional_command
         print("An error occurred while trying to create process from the file at " + process_path)
         detach()
         return False
+
+    send_command("starti")
+    wait_for_stop()
+
     entry_point = find_entry_point()
     if entry_point:
         send_command("b *" + entry_point)


### PR DESCRIPTION
The 'create process' feature appears to be a bit broken.

```
[user202729@archlinux PINCE]$ gdb a
GNU gdb (GDB) 8.1
[...]
Reading symbols from a...(no debugging symbols found)...done.
(gdb) info file
Symbols from "/home/user202729/PINCE/a".
Local exec file:
        `/home/user202729/PINCE/a', file type elf64-x86-64.
        Entry point: 0x520
        [...]
(gdb) starti
Starting program: /home/user202729/PINCE/a 

Program stopped.
0x00007ffff7dd8fb0 in _start () from /lib64/ld-linux-x86-64.so.2
(gdb) info file
Symbols from "/home/user202729/PINCE/a".
Native process:
        Using the running image of child process 14714.
        While running this, GDB does not access memory from...
Local exec file:
        `/home/user202729/PINCE/a', file type elf64-x86-64.
        Entry point: 0x555555554520
        [...]
```

Before mapping the process to virtual memory, the "entry point" displayed is not the virtual address. So `starti` needs to be executed, otherwise it will only work with static executables.