### PR TITLE
Auto attach

### DIFF
--- a/GUI/SettingsDialog.py
+++ b/GUI/SettingsDialog.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'SettingsDialog.ui'
 #
-# Created by: PyQt5 UI code generator 5.5.1
+# Created by: PyQt5 UI code generator 5.11.2
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -94,6 +94,18 @@ class Ui_Dialog(object):
         spacerItem1 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         self.horizontalLayout_3.addItem(spacerItem1)
         self.verticalLayout_5.addLayout(self.horizontalLayout_3)
+        self.horizontalLayout_12 = QtWidgets.QHBoxLayout()
+        self.horizontalLayout_12.setContentsMargins(-1, 0, -1, -1)
+        self.horizontalLayout_12.setObjectName("horizontalLayout_12")
+        self.label_9 = QtWidgets.QLabel(self.page)
+        self.label_9.setWordWrap(True)
+        self.label_9.setObjectName("label_9")
+        self.horizontalLayout_12.addWidget(self.label_9)
+        self.plainTextEdit_autoAttachList = QtWidgets.QPlainTextEdit(self.page)
+        self.plainTextEdit_autoAttachList.setMaximumSize(QtCore.QSize(16777215, 38))
+        self.plainTextEdit_autoAttachList.setObjectName("plainTextEdit_autoAttachList")
+        self.horizontalLayout_12.addWidget(self.plainTextEdit_autoAttachList)
+        self.verticalLayout_5.addLayout(self.horizontalLayout_12)
         spacerItem2 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
         self.verticalLayout_5.addItem(spacerItem2)
         self.gridLayout.addLayout(self.verticalLayout_5, 0, 0, 1, 1)
@@ -272,6 +284,7 @@ class Ui_Dialog(object):
         self.checkBox_MessageBoxOnException.setText(_translate("Dialog", "Show a MessageBox on InferiorRunning and GDBInitialize exceptions"))
         self.checkBox_MessageBoxOnToggleAttach.setText(_translate("Dialog", "Show a MessageBox on Toggle Attach"))
         self.label_8.setText(_translate("Dialog", "GDB console output mode"))
+        self.label_9.setText(_translate("Dialog", "On start, automatically attach to processes with name matching one of the regex:"))
         self.label_3.setText(_translate("Dialog", "Functions"))
         self.label_4.setText(_translate("Dialog", "Hotkey"))
         self.pushButton_ClearHotkey.setText(_translate("Dialog", "Clear"))

--- a/GUI/SettingsDialog.ui
+++ b/GUI/SettingsDialog.ui
@@ -184,6 +184,33 @@
               </layout>
              </item>
              <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_12">
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QLabel" name="label_9">
+                 <property name="text">
+                  <string>On start, automatically attach to processes with name matching one of the regex:</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPlainTextEdit" name="plainTextEdit_autoAttachList">
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>38</height>
+                  </size>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
               <spacer name="verticalSpacer_2">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>

--- a/PINCE.py
+++ b/PINCE.py
@@ -82,6 +82,7 @@ code_injection_method = int
 bring_disassemble_to_front = bool
 instructions_per_scroll = int
 gdb_path = str
+auto_attach_list = list
 
 # represents the index of columns in breakpoint table
 BREAK_NUM_COL = 0
@@ -376,6 +377,7 @@ class MainForm(QMainWindow, MainWindow):
         self.settings.setValue("show_messagebox_on_exception", True)
         self.settings.setValue("show_messagebox_on_toggle_attach", True)
         self.settings.setValue("gdb_output_mode", type_defs.GDB_OUTPUT_MODE.UNMUTED)
+        self.settings.setValue("auto_attach_list", [])
         self.settings.endGroup()
         self.settings.beginGroup("Hotkeys")
         self.settings.setValue("pause_hotkey", "F1")
@@ -404,6 +406,7 @@ class MainForm(QMainWindow, MainWindow):
         global show_messagebox_on_exception
         global show_messagebox_on_toggle_attach
         global gdb_output_mode
+        global auto_attach_list
         global global_hotkeys
         global code_injection_method
         global bring_disassemble_to_front
@@ -414,6 +417,7 @@ class MainForm(QMainWindow, MainWindow):
         show_messagebox_on_exception = self.settings.value("General/show_messagebox_on_exception", type=bool)
         show_messagebox_on_toggle_attach = self.settings.value("General/show_messagebox_on_toggle_attach", type=bool)
         gdb_output_mode = self.settings.value("General/gdb_output_mode", type=int)
+        auto_attach_list = self.settings.value("General/auto_attach_list", type=list)
         GDB_Engine.set_gdb_output_mode(gdb_output_mode)
         for key, value in list(global_hotkeys.items()):
             value = self.settings.value("Hotkeys/" + key)
@@ -1321,6 +1325,7 @@ class SettingsDialogForm(QDialog, SettingsDialog):
                                                "\nSetting update interval less than 0.1 seconds may cause slowdown"
                                                "\nProceed?",)]).exec_():
                 return
+
         self.settings.setValue("General/auto_update_address_table", self.checkBox_AutoUpdateAddressTable.isChecked())
         if self.checkBox_AutoUpdateAddressTable.isChecked():
             self.settings.setValue("General/address_table_update_interval", current_table_update_interval)
@@ -1328,6 +1333,7 @@ class SettingsDialogForm(QDialog, SettingsDialog):
         self.settings.setValue("General/show_messagebox_on_toggle_attach",
                                self.checkBox_MessageBoxOnToggleAttach.isChecked())
         self.settings.setValue("General/gdb_output_mode", self.comboBox_GDBOutputMode.currentIndex())
+        self.settings.setValue("General/auto_attach_list", self.plainTextEdit_autoAttachList.toPlainText().splitlines())
         for key, value in list(global_hotkeys.items()):
             self.settings.setValue("Hotkeys/" + key, getattr(self, key))
         if self.radioButton_SimpleDLopenCall.isChecked():
@@ -1357,6 +1363,7 @@ class SettingsDialogForm(QDialog, SettingsDialog):
         self.checkBox_MessageBoxOnToggleAttach.setChecked(
             self.settings.value("General/show_messagebox_on_toggle_attach", type=bool))
         self.comboBox_GDBOutputMode.setCurrentIndex(self.settings.value("General/gdb_output_mode", type=int))
+        self.plainTextEdit_autoAttachList.setPlainText('\n'.join(self.settings.value("General/auto_attach_list", type=list)))
         self.listWidget_Functions.clear()
         self.listWidget_Functions.addItems(
             ["Pause the process", "Break the process", "Continue the process", "Toggle attach/detach"])

--- a/PINCE.py
+++ b/PINCE.py
@@ -340,6 +340,18 @@ class MainForm(QMainWindow, MainWindow):
             current_hotkey.activated.connect(getattr(self, key + "_pressed"))
             current_hotkey.setContext(Qt.ApplicationShortcut)
 
+        # Check if any process should be attached to automatically.
+        # Patterns at former position has higher priority.
+        procs = [(process.name(), process.pid) for process in SysUtils.get_process_list()]
+        for pattern in auto_attach_list:
+            for name, pid in procs:
+                if re.fullmatch(pattern, name):
+                    self.attach_to_pid(pid)
+                    break
+            else: # not found
+                continue
+            break # found. Python doesn't have a way to break out of multiple loops.
+
         # Saving the original function because super() doesn't work when we override functions like this
         self.treeWidget_AddressTable.keyPressEvent_original = self.treeWidget_AddressTable.keyPressEvent
         self.treeWidget_AddressTable.keyPressEvent = self.treeWidget_AddressTable_key_press_event


### PR DESCRIPTION
Allows PINCE to automatically attach to process with matching names when it's started. Useful for testing (although the popup "memory viewer" window can be annoying).

Cheat Engine has a similar feature, but it:

* Doesn't allow regex
* Can attach at all time, not just startup

It's allowed to attach to `self_pid` using this method.

-------

There is a nested for loop break at line 350, which may looks a bit confusing.