### PR TITLE
Don't write Python bytecode

### DIFF
--- a/PINCE.sh
+++ b/PINCE.sh
@@ -20,8 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 OS=$(lsb_release -si)
 # Get rid of gksudo when Debian 8 support drops or polkit gets implemented
 if [ $OS = "Debian" ] && [ -x "$(command -v gksudo)" ]; then
-  gksudo python3 PINCE.py
+  gksudo env PYTHONDONTWRITEBYTECODE=1 python3 PINCE.py
 else
   # Preserve env vars to keep settings like theme preferences
-  sudo -E python3 PINCE.py
+  sudo -E PYTHONDONTWRITEBYTECODE=1 python3 PINCE.py
 fi


### PR DESCRIPTION
This might cause conflicts when installing PINCE via a package manager, as running the program as root just allows it to drop its bytecode files where it wants and the installation directory would therefore contain files that aren't in the original package, causing warnings or even errors in the process.

Disabling writing bytecode to files might also keep users from having undeletable files in their home directory.