### PR TITLE
Fixed hardcoded black text color for dark themes

### DIFF
--- a/GUI/CustomLabels/FlagRegisterLabel.py
+++ b/GUI/CustomLabels/FlagRegisterLabel.py
@@ -31,7 +31,7 @@ class QFlagRegisterLabel(QLabel):
         if old != new:
             self.setStyleSheet("color: red")
         else:
-            self.setStyleSheet("color: black")
+            self.setStyleSheet("")
         self.setText(new)
 
     def enterEvent(self, QEvent):

--- a/GUI/CustomLabels/RegisterLabel.py
+++ b/GUI/CustomLabels/RegisterLabel.py
@@ -32,7 +32,7 @@ class QRegisterLabel(QLabel):
         if old != new:
             self.setStyleSheet("color: red")
         else:
-            self.setStyleSheet("color: black")
+            self.setStyleSheet("")
         self.setText(new)
 
     def enterEvent(self, QEvent):


### PR DESCRIPTION
Due to the color: black stylesheet that is used for when a register has not changed, the register texts are almost unreadable on dark themes after process attachment:
![Issue](https://user-images.githubusercontent.com/28410865/159192282-f4d110b8-15a6-43d8-b9e9-3007c3a18174.png)


This fix allows the color property to be reset back to it's initial value, which would be white for dark themes and black for the white themes.