### PR TITLE
Move intltool to PKG_NAMES_ALL

### DIFF
--- a/install_pince.sh
+++ b/install_pince.sh
@@ -64,11 +64,11 @@ OS_NAME="Debian"
 PKG_MGR="apt-get"
 INSTALL_COMMAND="install"
 
-PKG_NAMES_ALL="python3-pip gdb"
-PKG_NAMES_DEBIAN="$PKG_NAMES_ALL python3-pyqt5 libtool libreadline-dev intltool"
+PKG_NAMES_ALL="python3-pip gdb intltool"
+PKG_NAMES_DEBIAN="$PKG_NAMES_ALL python3-pyqt5 libtool libreadline-dev"
 PKG_NAMES_SUSE="$PKG_NAMES_ALL python3-qt5"
-PKG_NAMES_FEDORA="$PKG_NAMES_ALL python3-qt5 libtool readline-devel python3-devel intltool"
-PKG_NAMES_ARCH="python-pip python-pyqt5 readline intltool gdb lsb-release" # arch defaults to py3 nowadays
+PKG_NAMES_FEDORA="$PKG_NAMES_ALL python3-qt5 libtool readline-devel python3-devel"
+PKG_NAMES_ARCH="python-pip python-pyqt5 readline gdb lsb-release" # arch defaults to py3 nowadays
 PKG_NAMES="$PKG_NAMES_DEBIAN"
 PKG_NAMES_PIP="psutil pexpect distorm3 pygdbmi keyboard"
 PIP_COMMAND="pip3"


### PR DESCRIPTION
As a SUSE user, `scanmem` failed to compile because it did not have this dependency. I am unsure why it was omitted but moving it to `PKG_NAMES_ALL` and running `install_pince.sh` did the trick, and PINCE can now properly run. Since all distros: Debian, SUSE (now), Fedora, and Arch use the dependency, I felt it was fine to move it to the the `PKG_NAMES_ALL`