### PR TITLE
Fix shellcheck issues on install scripts

### DIFF
--- a/install_gdb.sh
+++ b/install_gdb.sh
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 GDB_VERSION="gdb-10.2"
 
 mkdir -p gdb_pince
-cd gdb_pince
+cd gdb_pince || exit
 
 # clean the directory if another installation happened
 rm -rf $GDB_VERSION
@@ -31,29 +31,32 @@ if [ ! -e ${GDB_VERSION}.tar.gz ] ; then
     wget "http://ftp.gnu.org/gnu/gdb/${GDB_VERSION}.tar.gz"
 fi
 tar -zxvf ${GDB_VERSION}.tar.gz
-cd $GDB_VERSION
+cd $GDB_VERSION || exit
 echo "-------------------------------------------------------------------------"
 echo "DISCLAIMER"
 echo "-------------------------------------------------------------------------"
 echo "If you're not on debian or a similar distro with the 'apt' package manager the follow will not work if you don't have gcc and g++ installed"
 echo "Please install them manually for this to work, this issue will be addressed at a later date"
-command -v gcc g++ # extremely lazy fix for other distros, if gcc&g++ is available it will work, if not it won't
-if [ $? -gt 0 ]; then
+
+ # extremely lazy fix for other distros, if gcc&g++ is available it will work, if not it won't
+if ! command -v gcc g++; then
     # Dependencies required for compiling GDB
     sudo apt-get install python3-dev
-    sudo apt-get install gcc g++
-    if [ $? -gt 0 ]; then
+
+    if ! sudo apt-get install gcc g++; then
         sudo apt-get install software-properties-common
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
-        sudo apt-get install gcc g++
-        if [ $? -gt 0 ]; then
+
+        if ! sudo apt-get install gcc g++; then
             echo "Failed to install gcc or g++, aborting..."
             exit 1
         fi
     fi
 fi
-CC=gcc CXX=g++ ./configure --prefix="$(pwd)" --with-python=python3 && make -j $(grep -m 1 "cpu cores" /proc/cpuinfo | cut -d: -f 2 | xargs) MAKEINFO=true && sudo make -C gdb install
+
+CC=gcc CXX=g++ ./configure --prefix="$(pwd)" --with-python=python3 && make -j MAKEINFO=true && sudo make -C gdb install
+
 if [ ! -e bin/gdb ] ; then
     echo "Failed to install GDB, restart the installation process"
     exit 1

--- a/install_pince.sh
+++ b/install_pince.sh
@@ -27,14 +27,14 @@ CURRENT_USER="$(who mom likes | awk '{print $1}')"
 compile_scanmem() {
     sh autogen.sh
     ./configure --prefix="$(pwd)"
-    make -j $(grep -m 1 "cpu cores" /proc/cpuinfo | cut -d: -f 2 | xargs) libscanmem.la
+    make -j libscanmem.la
     chown -R "${CURRENT_USER}":"${CURRENT_USER}" . # give permissions for normal user to change file
 }
 
 install_scanmem() {
     echo "Downloading scanmem"
     git submodule update --init --recursive
-    
+
     if [ ! -d "libpince/libscanmem" ]; then
         mkdir libpince/libscanmem
         chown -R "${CURRENT_USER}":"${CURRENT_USER}" libpince/libscanmem
@@ -42,7 +42,7 @@ install_scanmem() {
     (
         echo "Entering scanmem"
         cd scanmem || exit
-        if [ -d "./.libs" ]; then 
+        if [ -d "./.libs" ]; then
             echo "Recompile scanmem? [y/n]"
             read -r answer
             if echo "$answer" | grep -iq "^[Yy]"; then
@@ -77,6 +77,7 @@ LSB_RELEASE="$(command -v lsb_release)"
 if [ -n "$LSB_RELEASE" ] ; then
     OS_NAME="$(${LSB_RELEASE} -d -s)"
 else
+    # shellcheck disable=SC1091
     . /etc/os-release
     OS_NAME="$NAME"
 fi
@@ -98,7 +99,9 @@ case "$OS_NAME" in
     ;;
 esac
 
+# shellcheck disable=SC2086
 sudo ${PKG_MGR} ${INSTALL_COMMAND} ${PKG_NAMES}
+# shellcheck disable=SC2086
 sudo ${PIP_COMMAND} install ${PKG_NAMES_PIP}
 
 install_scanmem


### PR DESCRIPTION
Also removed unnecessary grepping for how many cores are available. `make -j` automatically uses the maximum amount if none are specified.