### PR TITLE
Feature exit install script on error

### DIFF
--- a/install_pince.sh
+++ b/install_pince.sh
@@ -65,7 +65,7 @@ install_scanmem() {
         cp --preserve gui/scanmem.py ../libpince/libscanmem
         cp --preserve gui/misc.py ../libpince/libscanmem
         echo "Exiting scanmem"
-    )
+    ) || return 1
     # required for relative import, since it will throw an import error if it's just `import misc`
     sed -i 's/import misc/from \. import misc/g' libpince/libscanmem/scanmem.py
     return 0

--- a/install_pince.sh
+++ b/install_pince.sh
@@ -99,7 +99,7 @@ case "$OS_NAME" in
     PKG_MGR="zypper"
     PKG_NAMES="$PKG_NAMES_SUSE"
     ;;
-*Arch* | *SteamOS*)
+*Arch*)
     PKG_MGR="pacman"
     PKG_NAMES="$PKG_NAMES_ARCH"
     INSTALL_COMMAND="-S"

--- a/install_pince.sh
+++ b/install_pince.sh
@@ -97,7 +97,7 @@ case "$OS_NAME" in
     PKG_MGR="zypper"
     PKG_NAMES="$PKG_NAMES_SUSE"
     ;;
-*Arch*)
+*Arch* | *SteamOS*)
     PKG_MGR="pacman"
     PKG_NAMES="$PKG_NAMES_ARCH"
     INSTALL_COMMAND="-S"


### PR DESCRIPTION
Small PR

Trying to solve the "Always Showing Successful installation" issue. 

- Add Exit on Error Function
- also inofficially added SteamOS to the Switch Case 

Locally Tested with Xubuntu 20.04 with Python 3.10 in a successful run and in multiple artificially failing runs. 

(Thats my first Public PR, so i'm not sure if its correct or not. Feedback appreciated) 

Bastian