### PR TITLE
BUGFIX having to press `First Scan` twice in initial scan

### DIFF
--- a/PINCE.py
+++ b/PINCE.py
@@ -457,7 +457,7 @@ class MainForm(QMainWindow, MainWindow):
         self.pushButton_Save.clicked.connect(self.pushButton_Save_clicked)
         self.pushButton_NewFirstScan.clicked.connect(self.pushButton_NewFirstScan_clicked)
         self.pushButton_NextScan.clicked.connect(self.pushButton_NextScan_clicked)
-        self.scan_mode = type_defs.SCAN_MODE.ONGOING
+        self.scan_mode = type_defs.SCAN_MODE.NEW
         self.pushButton_NewFirstScan_clicked()
         self.comboBox_ScanScope_init()
         self.comboBox_ValueType_init()

--- a/PINCE.py
+++ b/PINCE.py
@@ -1008,8 +1008,8 @@ class MainForm(QMainWindow, MainWindow):
 
     # TODO add a damn keybind for this...
     def pushButton_NewFirstScan_clicked(self):
-        self.comboBox_ScanType_init()
         if GDB_Engine.currentpid == -1:
+            self.comboBox_ScanType_init()
             return
         if self.scan_mode == type_defs.SCAN_MODE.ONGOING:
             self.scan_mode = type_defs.SCAN_MODE.NEW
@@ -1030,6 +1030,8 @@ class MainForm(QMainWindow, MainWindow):
             self.backend.send_command("reset")
             self.comboBox_ScanScope.setEnabled(False)
             self.pushButton_NextScan_clicked()  # makes code a little simpler to just implement everything in nextscan
+
+        self.comboBox_ScanType_init()
 
     def comboBox_ScanType_current_index_changed(self):
         hidden_types = [type_defs.SCAN_TYPE.INCREASED, type_defs.SCAN_TYPE.DECREASED, type_defs.SCAN_TYPE.CHANGED,


### PR DESCRIPTION
To do an initial scan, I have to press the `First Scan` twice in order to have 
matches in the matches table, this seems to hapen because of wrong 
`self.scan_mode` value in `MainForm`

Initially `self.scan_mode` is `type_defs.SCAN_MODE.ONGOING`
shouldn't it be `self.scan_mode` be `type_defs.SCAN_MODE.NEW` ?