### PR TITLE
Show confirmation dialog when doing `New Scan`

### DIFF
--- a/PINCE.py
+++ b/PINCE.py
@@ -1012,6 +1012,17 @@ class MainForm(QMainWindow, MainWindow):
             self.comboBox_ScanType_init()
             return
         if self.scan_mode == type_defs.SCAN_MODE.ONGOING:
+            # ask user for confirmation via confirmation dialog
+            msg_box = QMessageBox()
+            msg_box.setIcon(QMessageBox.Icon.Question)
+            msg_box.setWindowTitle("New Scan")
+            msg_box.setText("Create a new scan ?")
+            msg_box.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel)
+            ret_val = msg_box.exec()
+            # if user cancel just exist
+            if ret_val == QMessageBox.StandardButton.Cancel:
+                return
+            # reset scan results
             self.scan_mode = type_defs.SCAN_MODE.NEW
             self.pushButton_NewFirstScan.setText("First Scan")
             self.backend.send_command("reset")

--- a/PINCE.py
+++ b/PINCE.py
@@ -1019,7 +1019,7 @@ class MainForm(QMainWindow, MainWindow):
             msg_box.setText("Create a new scan ?")
             msg_box.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel)
             ret_val = msg_box.exec()
-            # if user cancel just exist
+            # if user cancel just exit
             if ret_val == QMessageBox.StandardButton.Cancel:
                 return
             # reset scan results


### PR DESCRIPTION
Problem:
	Sometimes I find my self accidently clicking `New Scan`
	Button when doing many scan operation because those
	buttons are close together

	for example when I am searching for player's y value
	for making fly hack, When I accidently clicked `New Scan`

	all of my hardwork will be gone in an instant :(
Solution:
	a confirmation dialog will be nice to have :)