### PR TITLE
Add Python 3 dev headers for APT distros

### DIFF
--- a/install_pince.sh
+++ b/install_pince.sh
@@ -106,7 +106,7 @@ ask_pkg_mgr() {
 }
 
 PKG_NAMES_ALL="python3-pip gdb libtool intltool"
-PKG_NAMES_DEBIAN="$PKG_NAMES_ALL libreadline-dev"
+PKG_NAMES_DEBIAN="$PKG_NAMES_ALL libreadline-dev python3-dev"
 PKG_NAMES_SUSE="$PKG_NAMES_ALL gcc readline-devel python3-devel typelib-1_0-Gtk-3_0 make"
 PKG_NAMES_FEDORA="$PKG_NAMES_ALL readline-devel python3-devel"
 PKG_NAMES_ARCH="python-pip readline intltool gdb lsb-release" # arch defaults to py3 nowadays


### PR DESCRIPTION
Needed for Debian based distros that do not come with Python 3 headers by default.