### PR TITLE
add pygobject as dependecy

### DIFF
--- a/install_pince.sh
+++ b/install_pince.sh
@@ -110,7 +110,7 @@ PKG_NAMES_DEBIAN="$PKG_NAMES_ALL libreadline-dev python3-dev"
 PKG_NAMES_SUSE="$PKG_NAMES_ALL gcc readline-devel python3-devel typelib-1_0-Gtk-3_0 make"
 PKG_NAMES_FEDORA="$PKG_NAMES_ALL readline-devel python3-devel"
 PKG_NAMES_ARCH="python-pip readline intltool gdb lsb-release" # arch defaults to py3 nowadays
-PKG_NAMES_PIP="pyqt6 psutil pexpect distorm3 pygdbmi keyboard"
+PKG_NAMES_PIP="pyqt6 psutil pexpect distorm3 pygdbmi keyboard pygobject"
 PIP_COMMAND="pip3"
 
 INSTALL_COMMAND="install"


### PR DESCRIPTION
fixes "AttributeError: module 'gi' has no attribute 'require_version'"