### PR TITLE
Change PINCE installation to use Python venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ libpince/libscanmem/*
 *$py.class
 gdb_pince/*
 *.gnbs.conf
+.venv/*

--- a/PINCE.sh
+++ b/PINCE.sh
@@ -16,6 +16,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '
 
+if [ ! -d ".venv/PINCE" ]; then
+	echo "Please run \"sh install_pince.sh\" first!"
+	exit 1
+fi
+
 # Change this bullcrap when polkit is implemented
 OS=$(lsb_release -si)
 # Get rid of gksudo when Debian 8 support drops or polkit gets implemented
@@ -23,5 +28,6 @@ if [ $OS = "Debian" ] && [ -x "$(command -v gksudo)" ]; then
   gksudo env PYTHONDONTWRITEBYTECODE=1 python3 PINCE.py
 else
   # Preserve env vars to keep settings like theme preferences
+  source .venv/PINCE/bin/activate
   sudo -E PYTHONDONTWRITEBYTECODE=1 python3 PINCE.py
 fi

--- a/PINCE.sh
+++ b/PINCE.sh
@@ -20,7 +20,7 @@ if [ ! -d ".venv/PINCE" ]; then
 	echo "Please run \"sh install_pince.sh\" first!"
 	exit 1
 fi
-source .venv/PINCE/bin/activate
+. .venv/PINCE/bin/activate
 
 # Change this bullcrap when polkit is implemented
 OS=$(lsb_release -si)

--- a/PINCE.sh
+++ b/PINCE.sh
@@ -22,12 +22,7 @@ if [ ! -d ".venv/PINCE" ]; then
 fi
 . .venv/PINCE/bin/activate
 
-# Change this bullcrap when polkit is implemented
-OS=$(lsb_release -si)
-# Get rid of gksudo when Debian 8 support drops or polkit gets implemented
-if [ $OS = "Debian" ] && [ -x "$(command -v gksudo)" ]; then
-  gksudo env PYTHONDONTWRITEBYTECODE=1 python3 PINCE.py
-else
-  # Preserve env vars to keep settings like theme preferences
-  sudo -E PYTHONDONTWRITEBYTECODE=1 python3 PINCE.py
-fi
+# Preserve env vars to keep settings like theme preferences.
+# Debian/Ubuntu does not preserve PATH through sudo even with -E for security reasons
+# so we need to force PATH preservation with venv activated user's PATH.
+sudo -E --preserve-env=PATH PYTHONDONTWRITEBYTECODE=1 python3 PINCE.py

--- a/PINCE.sh
+++ b/PINCE.sh
@@ -20,6 +20,7 @@ if [ ! -d ".venv/PINCE" ]; then
 	echo "Please run \"sh install_pince.sh\" first!"
 	exit 1
 fi
+source .venv/PINCE/bin/activate
 
 # Change this bullcrap when polkit is implemented
 OS=$(lsb_release -si)
@@ -28,6 +29,5 @@ if [ $OS = "Debian" ] && [ -x "$(command -v gksudo)" ]; then
   gksudo env PYTHONDONTWRITEBYTECODE=1 python3 PINCE.py
 else
   # Preserve env vars to keep settings like theme preferences
-  source .venv/PINCE/bin/activate
   sudo -E PYTHONDONTWRITEBYTECODE=1 python3 PINCE.py
 fi

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Pre-release screenshots:
 ```
 git clone --recursive https://github.com/korcankaraokcu/PINCE
 cd PINCE
-sudo sh install_pince.sh
+sh install_pince.sh
 ```
 ~~For Archlinux, you can also use the [AUR package](https://aur.archlinux.org/packages/pince-git/) as an alternative~~ Currently outdated, use the installation script
 

--- a/install_pince.sh
+++ b/install_pince.sh
@@ -106,7 +106,7 @@ ask_pkg_mgr() {
 }
 
 PKG_NAMES_ALL="python3-pip gdb libtool intltool"
-PKG_NAMES_DEBIAN="$PKG_NAMES_ALL libreadline-dev python3-dev"
+PKG_NAMES_DEBIAN="$PKG_NAMES_ALL libreadline-dev python3-dev python3-venv pkg-config libcairo2-dev libgirepository1.0-dev"
 PKG_NAMES_SUSE="$PKG_NAMES_ALL gcc readline-devel python3-devel typelib-1_0-Gtk-3_0 make"
 PKG_NAMES_FEDORA="$PKG_NAMES_ALL readline-devel python3-devel redhat-lsb"
 PKG_NAMES_ARCH="python-pip readline intltool gdb lsb-release" # arch defaults to py3 nowadays

--- a/install_pince.sh
+++ b/install_pince.sh
@@ -170,7 +170,7 @@ sudo ${PKG_MGR} ${INSTALL_COMMAND} ${PKG_NAMES} || exit_on_error
 if [ ! -d ".venv/PINCE" ]; then
 	python3 -m venv .venv/PINCE
 fi
-source .venv/PINCE/bin/activate
+. .venv/PINCE/bin/activate
 
 # shellcheck disable=SC2086
 pip3 install ${PKG_NAMES_PIP} || exit_on_error

--- a/install_pince.sh
+++ b/install_pince.sh
@@ -111,7 +111,6 @@ PKG_NAMES_SUSE="$PKG_NAMES_ALL gcc readline-devel python3-devel typelib-1_0-Gtk-
 PKG_NAMES_FEDORA="$PKG_NAMES_ALL readline-devel python3-devel redhat-lsb"
 PKG_NAMES_ARCH="python-pip readline intltool gdb lsb-release" # arch defaults to py3 nowadays
 PKG_NAMES_PIP="pyqt6 psutil pexpect distorm3 pygdbmi keyboard pygobject"
-PIP_COMMAND="pip3"
 
 INSTALL_COMMAND="install"
 
@@ -125,7 +124,6 @@ set_install_vars() {
 		PKG_MGR="pacman"
 		PKG_NAMES="$PKG_NAMES_ARCH"
 		INSTALL_COMMAND="-S --needed"
-		PIP_COMMAND="pip"
 		;;
 	*Fedora*)
 		PKG_MGR="dnf -y"
@@ -167,8 +165,15 @@ fi
 
 # shellcheck disable=SC2086
 sudo ${PKG_MGR} ${INSTALL_COMMAND} ${PKG_NAMES} || exit_on_error
+
+# Prepare Python virtual environment
+if [ ! -d ".venv/PINCE" ]; then
+	python3 -m venv .venv/PINCE
+fi
+source .venv/PINCE/bin/activate
+
 # shellcheck disable=SC2086
-sudo ${PIP_COMMAND} install ${PKG_NAMES_PIP} || exit_on_error
+pip3 install ${PKG_NAMES_PIP} || exit_on_error
 
 install_scanmem || exit_on_error
 

--- a/install_pince.sh
+++ b/install_pince.sh
@@ -107,8 +107,8 @@ ask_pkg_mgr() {
 
 PKG_NAMES_ALL="python3-pip gdb libtool intltool"
 PKG_NAMES_DEBIAN="$PKG_NAMES_ALL libreadline-dev python3-dev python3-venv pkg-config libcairo2-dev libgirepository1.0-dev"
-PKG_NAMES_SUSE="$PKG_NAMES_ALL gcc readline-devel python3-devel typelib-1_0-Gtk-3_0 make"
-PKG_NAMES_FEDORA="$PKG_NAMES_ALL readline-devel python3-devel redhat-lsb"
+PKG_NAMES_SUSE="$PKG_NAMES_ALL gcc readline-devel python3-devel typelib-1_0-Gtk-3_0 cairo-devel gobject-introspection-devel make"
+PKG_NAMES_FEDORA="$PKG_NAMES_ALL readline-devel python3-devel redhat-lsb cairo-devel gobject-introspection-devel cairo-gobject-devel"
 PKG_NAMES_ARCH="python-pip readline intltool gdb lsb-release" # arch defaults to py3 nowadays
 PKG_NAMES_PIP="pyqt6 psutil pexpect distorm3 pygdbmi keyboard pygobject"
 

--- a/libpince/GDB_Engine.py
+++ b/libpince/GDB_Engine.py
@@ -491,7 +491,7 @@ def init_gdb(gdb_path=type_defs.PATHS.GDB_PATH):
     last_gdb_command = ""
 
     libpince_dir = SysUtils.get_libpince_directory()
-    child = pexpect.spawn('sudo LC_NUMERIC=C ' + gdb_path + ' --interpreter=mi', cwd=libpince_dir,
+    child = pexpect.spawn('sudo LC_NUMERIC=C -E ' + gdb_path + ' --interpreter=mi', cwd=libpince_dir,
                           encoding="utf-8")
     child.setecho(False)
     child.delaybeforesend = 0

--- a/libpince/GDB_Engine.py
+++ b/libpince/GDB_Engine.py
@@ -491,7 +491,7 @@ def init_gdb(gdb_path=type_defs.PATHS.GDB_PATH):
     last_gdb_command = ""
 
     libpince_dir = SysUtils.get_libpince_directory()
-    child = pexpect.spawn('sudo LC_NUMERIC=C -E ' + gdb_path + ' --interpreter=mi', cwd=libpince_dir,
+    child = pexpect.spawn('sudo -E --preserve-env=PATH LC_NUMERIC=C ' + gdb_path + ' --interpreter=mi', cwd=libpince_dir,
                           encoding="utf-8")
     child.setecho(False)
     child.delaybeforesend = 0
@@ -502,6 +502,7 @@ def init_gdb(gdb_path=type_defs.PATHS.GDB_PATH):
     status_thread.start()
     gdb_initialized = True
     set_logging(False)
+    send_command("source ./gdbinit_venv")
     send_command("source " + SysUtils.get_user_path(type_defs.USER_PATHS.GDBINIT_PATH))
     SysUtils.execute_script(SysUtils.get_user_path(type_defs.USER_PATHS.PINCEINIT_PATH))
 

--- a/libpince/gdbinit_venv
+++ b/libpince/gdbinit_venv
@@ -1,0 +1,14 @@
+# Update GDB's Python paths with the `sys.path` values of the local
+# Python installation, whether that is brew'ed Python, a virtualenv,
+# or another system python.
+
+# Convert GDB to interpret in Python
+python
+import os,subprocess,sys
+
+# Execute a Python using the user's shell and pull out the sys.path (for site-packages)
+paths = subprocess.check_output('python -c "import os,sys;print(os.linesep.join(sys.path).strip())"',shell=True).decode("utf-8").split()
+
+# Extend GDB's Python's search path
+sys.path.extend(paths)
+end


### PR DESCRIPTION
PINCE installer should now create a ".venv/PINCE" folder that will contain the virtual environment that PINCE will now run in.