### PR TITLE
Update SysUtils.py

### DIFF
--- a/libpince/SysUtils.py
+++ b/libpince/SysUtils.py
@@ -31,7 +31,7 @@ def get_process_list():
         list: List of (pid, user, process_name) -> (str, str, str)
     """
     process_list = []
-    for line in os.popen("ps -eo pid,user,comm").read().splitlines():
+    for line in os.popen("ps -eo pid:11,user,comm").read().splitlines():
         info = common_regexes.ps.match(line)
         if info:
             process_list.append(common_regexes.ps.match(line).groups())


### PR DESCRIPTION
due to regex used to validate a line returned by ps -eo, each line that doesn't begin with blank char is ignored. This results in processes with PID higher than 999999 to be ignored and not listed in process selector. This trivial change works around the problem by forcing PID column in ps output to always be 11 characters wide.