### PR TITLE
Limit make jobs to 4 to prevent OOM

### DIFF
--- a/install_gdb.sh
+++ b/install_gdb.sh
@@ -40,7 +40,7 @@ echo "Please install them manually for this to work, this issue will be addresse
 
 sudo apt-get install python3-dev libgmp3-dev
 
-CC=gcc CXX=g++ ./configure --prefix="$(pwd)" --with-python=python3 && make -j MAKEINFO=true && sudo make -C gdb install
+CC=gcc CXX=g++ ./configure --prefix="$(pwd)" --with-python=python3 && make -j4 MAKEINFO=true && sudo make -j4 -C gdb install
 
 if [ ! -e bin/gdb ] ; then
     echo "Failed to install GDB, restart the installation process"

--- a/install_gdb.sh
+++ b/install_gdb.sh
@@ -49,7 +49,7 @@ echo "-------------------------------------------------------------------------"
 echo "If you're not on debian or a similar distro with the 'apt' package manager the follow will not work if you don't have gcc and g++ installed"
 echo "Please install them manually for this to work, this issue will be addressed at a later date"
 
-apt-get install python3-dev libgmp3-dev
+sudo apt-get install python3-dev libgmp3-dev
 
 CC=gcc CXX=g++ ./configure --prefix="$(pwd)" --with-python=python3 && make -j"$NUM_MAKE_JOBS" MAKEINFO=true && sudo make -C gdb install
 

--- a/install_pince.sh
+++ b/install_pince.sh
@@ -40,7 +40,7 @@ exit_on_error() {
 compile_scanmem() {
     sh autogen.sh || return 1
     ./configure --prefix="$(pwd)" || return 1
-    make -j libscanmem.la || return 1
+    make -j4 libscanmem.la || return 1
     chown -R "${CURRENT_USER}":"${CURRENT_USER}" . # give permissions for normal user to change file
     return 0
 }

--- a/install_pince.sh
+++ b/install_pince.sh
@@ -27,6 +27,17 @@ fi
 
 CURRENT_USER="$(who mom likes | awk '{print $1}')"
 
+if [ -z "$NUM_MAKE_JOBS" ]; then
+    NUM_MAKE_JOBS=$(lscpu -p=core | uniq | awk '!/#/' | wc -l)
+    MAX_NUM_MAKE_JOBS=8
+    if (( NUM_MAKE_JOBS > MAX_NUM_MAKE_JOBS )); then # set an upper limit to prevent Out-Of-Memory
+        NUM_MAKE_JOBS=$MAX_NUM_MAKE_JOBS
+    fi
+    if ! echo "$NUM_MAKE_JOBS" | grep -Eq '^[0-9]+$'; then # fallback
+        NUM_MAKE_JOBS=$MAX_NUM_MAKE_JOBS
+    fi
+fi
+
 exit_on_error() {
     if [ "$?" -ne 0 ]; then
         echo
@@ -40,7 +51,7 @@ exit_on_error() {
 compile_scanmem() {
     sh autogen.sh || return 1
     ./configure --prefix="$(pwd)" || return 1
-    make -j4 libscanmem.la || return 1
+    make -j"$NUM_MAKE_JOBS" libscanmem.la || return 1
     chown -R "${CURRENT_USER}":"${CURRENT_USER}" . # give permissions for normal user to change file
     return 0
 }


### PR DESCRIPTION
My laptop (16 CPU threads, 64GB memory) went Out-Of-Memory while compiling GDB. I think the culprit here is `-j`. I saw from `man make`:

```
If the -j option is given without an argument, make will not limit the number of jobs that can run simultaneously.
```

I tested running the script again after a fresh reboot and the same thing happened again.