### PR TITLE
Scanmem changes

### DIFF
--- a/install_pince.sh
+++ b/install_pince.sh
@@ -78,11 +78,8 @@ install_scanmem() {
         fi
         cp --preserve .libs/libscanmem.so ../libpince/libscanmem/
         cp --preserve wrappers/scanmem.py ../libpince/libscanmem
-        cp --preserve wrappers/misc.py ../libpince/libscanmem
         echo "Exiting scanmem"
     ) || return 1
-    # required for relative import, since it will throw an import error if it's just `import misc`
-    sed -i 's/import misc/from \. import misc/g' libpince/libscanmem/scanmem.py
     return 0
 }
 


### PR DESCRIPTION
These commits remove misc.py completely and any GTK dependency needed from scanmem-PINCE fork.