### PR TITLE
Fix vimspector missing modules issue

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -19,7 +19,10 @@
         "justMyCode": false,
         "sudo": true,
         "console": "integratedTerminal",
-        "program": "${workspaceFolder}/PINCE.py"
+        "program": "${workspaceFolder}/PINCE.py",
+        "env": {
+          "PATH": "${PATH}"
+        }
       },
       "breakpoints": {
         "exception": {


### PR DESCRIPTION
Vimspector broke after we did preserve-env=PATH fixes for Debian/Ubuntu