### PR TITLE
Libscanmem undo changes

### DIFF
--- a/PINCE.py
+++ b/PINCE.py
@@ -1101,7 +1101,7 @@ class MainForm(QMainWindow, MainWindow):
             value = "" if value is None else str(value)
             row.setText(VALUE_COL, value)
 
-    def scan_for_values(self):
+    def scan_values(self):
         global threadpool
         if debugcore.currentpid == -1:
             return
@@ -1174,7 +1174,7 @@ class MainForm(QMainWindow, MainWindow):
             scanmem.reset()
             self.comboBox_ScanScope.setEnabled(False)
             self.comboBox_Endianness.setEnabled(False)
-            self.scan_for_values()
+            self.scan_values()
         self.comboBox_ScanType_init()
 
     def pushButton_UndoScan_clicked(self):
@@ -1287,7 +1287,7 @@ class MainForm(QMainWindow, MainWindow):
         return search_for
 
     def pushButton_NextScan_clicked(self):
-        self.scan_for_values()
+        self.scan_values()
         self.pushButton_UndoScan.setEnabled(True)
 
     def scan_callback(self):


### PR DESCRIPTION
Short description for libscanmem changes:
- Removed redo as it was redundant for PINCE.
- Limited undo to one single undo instead of unlimited entries
- Will store current matches only after starting a new scan so we don't double store upon searching. This will prevent allocating memory if an user only needs one search, unlikely but still.

Short description for PINCE changes:
- Moved value scanning code to it's own function instead of NextScan_clicked.
- Removed undo stuff from scanning code and moved it to UndoScan_clicked.
- Undo scan button will now be set to true only after clicking Next Scan, instead of either New or Next. This is due to the last point in the libscanmem changes, where we only store the undo entry after starting a new scan, so we won't have anything to undo upon first scan.