### PR TITLE
FEAT add key handler to remove search results

### DIFF
--- a/PINCE.py
+++ b/PINCE.py
@@ -1731,7 +1731,7 @@ class ProcessForm(QMainWindow, ProcessWindow):
     def keyPressEvent(self, event):
         if event.key() == Qt.Key.Key_Escape:
             self.close()
-        elif event.key() == Qt.Key.Key_Return:
+        elif event.key() == Qt.Key.Key_Return or event.key() == Qt.Key.Key_Enter:
             self.pushButton_Open_clicked()
         elif event.key() == Qt.Key.Key_F1:
             self.pushButton_CreateProcess_clicked()

--- a/PINCE.py
+++ b/PINCE.py
@@ -922,6 +922,8 @@ class MainForm(QMainWindow, MainWindow):
             (QKeyCombination(Qt.KeyboardModifier.NoModifier, Qt.Key.Key_V), lambda: self.paste_records(True)),
             (QKeyCombination(Qt.KeyboardModifier.NoModifier, Qt.Key.Key_Return),
              self.treeWidget_AddressTable_edit_value),
+            (QKeyCombination(Qt.KeyboardModifier.KeypadModifier, Qt.Key.Key_Enter),
+             self.treeWidget_AddressTable_edit_value),
             (QKeyCombination(Qt.KeyboardModifier.ControlModifier, Qt.Key.Key_Return),
              self.treeWidget_AddressTable_edit_desc),
             (QKeyCombination(Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.AltModifier, Qt.Key.Key_Return),


### PR DESCRIPTION
This pull request adds key press event handling for deleting rows in the valuesearchtable. 
It allows users to delete selected rows by pressing the Delete key.

currently using scanmem.send_command() - possible rewrite to custom method in wrapper class ? 