### PR TITLE
Change read_pointer_chain to add 0 for invalid offset reads

### DIFF
--- a/PINCE.py
+++ b/PINCE.py
@@ -1901,13 +1901,23 @@ class ManualAddressDialogForm(QDialog, ManualAddressDialog):
         if pointer_chain_result != None:
             self.label_BaseAddressDeref.setText(f"-> {hex(pointer_chain_result.pointer_chain[0])}")
             for index, derefLabel in enumerate(self.offsetDerefLabels):
-                previousDeref = hex(pointer_chain_result.pointer_chain[index])
-                currentDeref = hex(pointer_chain_result.pointer_chain[index+1])
+                previousDerefValue = pointer_chain_result.pointer_chain[index]
+                if previousDerefValue == 0:
+                    previousDerefText = "<font color=red>??</font>"
+                else:
+                    previousDerefText = hex(previousDerefValue)
+
+                currentDerefValue = pointer_chain_result.pointer_chain[index+1]
+                if currentDerefValue == 0:
+                    currentDerefText = "<font color=red>??</font>"
+                else:
+                    currentDerefText = hex(currentDerefValue)
+
                 offsetText = self.offsetTextLabels[index].text()
                 if index != len(self.offsetDerefLabels) - 1:
-                    derefLabel.setText(f"[{previousDeref}+{offsetText}] -> {currentDeref}")
+                    derefLabel.setText(f"[{previousDerefText}+{offsetText}] -> {currentDerefText}")
                 else:
-                    derefLabel.setText(f"{previousDeref}+{offsetText} = {currentDeref}")
+                    derefLabel.setText(f"{previousDerefText}+{offsetText} = {currentDerefText}")
         else:
             self.label_BaseAddressDeref.setText(f"-> <font color=red>??</font>")
             for derefLabel in self.offsetDerefLabels:


### PR DESCRIPTION
This change will show where the pointer chain breaks right in the UI instead of replacing all entries with ?? if a single read is invalid.

![image](https://github.com/korcankaraokcu/PINCE/assets/28410865/e9800f3b-6e56-48e5-96f7-9cc57068aec2)
