### PR TITLE
Add Nix/NixOS support through Flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 TODO: Include build status with the title when test coverage increases and Travis is maintained
 [![Build Status](https://travis-ci.org/korcankaraokcu/PINCE.svg?branch=master)](https://travis-ci.org/korcankaraokcu/PINCE)
 -->
-PINCE is a front-end/reverse engineering tool for the GNU Project Debugger (GDB), focused on games. However, it can be used for any reverse-engineering related stuff. PINCE is an abbreviation for "PINCE is not Cheat Engine". PINCE is in development right now, read [Features](#features) part of the project to see what is done and [Roadmap](CONTRIBUTING.md#roadmap) part to see what is currently planned. Also, please read [Wiki Page](https://github.com/korcankaraokcu/PINCE/wiki) of the project to understand how PINCE works.  
+PINCE is a front-end/reverse engineering tool for the GNU Project Debugger (GDB), focused on games. However, it can be used for any reverse-engineering related stuff. PINCE is an abbreviation for "PINCE is not Cheat Engine". PINCE is in development right now, read [Features](#features) part of the project to see what is done and [Roadmap](CONTRIBUTING.md#roadmap) part to see what is currently planned. Also, please read [Wiki Page](https://github.com/korcankaraokcu/PINCE/wiki) of the project to understand how PINCE works.
 
-### [Feel free to join our discord server!](https://discord.gg/jVt3BzTSpz)  
+### [Feel free to join our discord server!](https://discord.gg/jVt3BzTSpz)
 
 *Disclaimer: Do not trust to any source other than [Trusted Sources](#trusted-sources) that claims to have the source code or package for PINCE and remember to report them **immediately***
 
@@ -24,7 +24,8 @@ Pre-release screenshots:
 ![pince8](https://user-images.githubusercontent.com/5638719/219640488-61a8df17-405b-45ae-9b29-f9d214eb8571.png)
 ![pince9](https://user-images.githubusercontent.com/5638719/219640522-85cac1a9-e425-4b4f-abeb-a61104caa618.png)
 
-# Features  
+# Features
+
 - **Memory searching:** PINCE uses a specialized fork of [libscanmem](https://github.com/brkzlr/scanmem-PINCE) to search the memory efficiently
 - **Background Execution:** PINCE uses background execution by default, allowing users to run GDB commands while process is running
 - **Variable Inspection&Modification**
@@ -60,39 +61,76 @@ Pre-release screenshots:
   * See [here](https://github.com/korcankaraokcu/PINCE/wiki/Extending-PINCE-with-.so-files)
 
 # Installing
-```
-git clone --recursive https://github.com/korcankaraokcu/PINCE
-cd PINCE
-sh install_pince.sh
-```
-~~For Archlinux, you can also use the [AUR package](https://aur.archlinux.org/packages/pince-git/) as an alternative~~ Currently outdated, use the installation script
 
-If you like to uninstall PINCE, just delete this folder, almost everything is installed locally. Config and user files of PINCE can be found in "~/.config/PINCE", you can manually delete them if you want
+With the installation script :
+
+```shell
+$ git clone --recursive https://github.com/korcankaraokcu/PINCE
+$ cd PINCE
+$ sh install_pince.sh
+```
+
+On Arch Linux, you can use the provided AUR package [pince-git]((https://aur.archlinux.org/packages/pince-git/)) :
+
+```shell
+$ yay -S pince-git
+```
+
+On Nix/NixOS, use the provided flake :
+
+```shell
+$ git clone --recursive https://github.com/korcankaraokcu/PINCE
+$ nix develop
+# or, with direnv
+# $ direnv allow .
+$ build-libscanmem
+```
+
+If you like to uninstall PINCE, just delete this folder, almost everything is installed locally. Config and user files of PINCE can be found in "~/.config/PINCE", you can manually delete them if you want.
 
 ***Notes:***
 - If you are having problems with your default gdb version, you can use the `install_gdb.sh` script to install another version locally. Read the comments in it for more information
 - Check https://github.com/korcankaraokcu/PINCE/issues/116 for a possible fix if you encounter `'GtkSettings' has no property named 'gtk-fallback-icon-theme'`
 
-# Running PINCE  
-Just run ```sh PINCE.sh``` in the PINCE directory
+# Running PINCE
+
+Just run the following in the PINCE directory :
+
+```shell
+$ sh PINCE.sh
+```
+
+On Nix/NixOS, run :
+
+```shell
+$ nix develop
+# or, with direnv
+# $ direnv allow .
+$ pince
+```
 
 # Contributing
+
 Want to help? Check out [CONTRIBUTING.md](CONTRIBUTING.md)
 
 # License
+
 GPLv3+. See [COPYING](COPYING) file for details
 
 # Officially supported platforms
+
 PINCE should technically run on any distro that comes with **Python 3.10+** and **PyQt 6.6+** installed or available in the package manager, but below is the list of distros that we officially support, as in we actively test on these and help with issues:
 - Ubuntu 22.04+
 - Debian 12+ (or Testing)
 - Archlinux
 - Fedora 35+
+- NixOS 23.11
 
 Should your distro not be officially supported, the installer can still try to install it for you by picking one of the base package managers appropriate for your distro but please **do not open an issue on GitHub** if it does not work for you.
 
 If this happens and you can't figure out why, we might be able to guide you into making PINCE run in our Discord server, under the #issues channel, but remember that we only actively test the installer and PINCE on the distros listed above.
 
 # Trusted Sources
-  * [Official github page](https://github.com/korcankaraokcu/PINCE)
-  * [AUR package for Archlinux](https://aur.archlinux.org/packages/pince-git/)
+
+* [Official github page](https://github.com/korcankaraokcu/PINCE)
+* [AUR package for Archlinux](https://aur.archlinux.org/packages/pince-git/)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,510 @@
+{
+  "nodes": {
+    "cachix": {
+      "inputs": {
+        "devenv": "devenv_2",
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": [
+          "devenv",
+          "pre-commit-hooks"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712055811,
+        "narHash": "sha256-7FcfMm5A/f02yyzuavJe06zLa9hcMHsagE28ADcmQvk=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "02e38da89851ec7fec3356a5c04bc8349cae0e30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "cachix": "cachix",
+        "flake-compat": "flake-compat_2",
+        "nix": "nix_2",
+        "nixpkgs": "nixpkgs_2",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1713632052,
+        "narHash": "sha256-kPlYLnGx8k6zOtzxws/Eb2OrFJWk6TwvMWiUDfw+nl8=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "9c134f73b11b298674317b84292fa126744a65fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devenv_2": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "cachix",
+          "flake-compat"
+        ],
+        "nix": "nix",
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix",
+        "pre-commit-hooks": [
+          "devenv",
+          "cachix",
+          "pre-commit-hooks"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708704632,
+        "narHash": "sha256-w+dOIW60FKMaHI1q5714CSibk99JfYxm0CzTinYWr+Q=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "2ee4450b0f4b95a1b90f2eb5ffea98b90e48c196",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "python-rewrite",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3",
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1713680591,
+        "narHash": "sha256-3pbv7UgAgetwz9YdjzIT/lZ6Rgj6wj6MR4mphBLyDjU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "19aaa94a73cc670a4d87e84f0909966cd8f8cd79",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "devenv",
+          "cachix",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1708577783,
+        "narHash": "sha256-92xq7eXlxIT5zFNccLpjiP7sdQqQI30Gyui2p/PfKZM=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "ecd0af0c1f56de32cbad14daa1d82a132bf298f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "devenv-2.21",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "cachix",
+          "devenv",
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688870561,
+        "narHash": "sha256-4UYkifnPEw1nAzqqPOTL2MvWtm3sNGw1UTYTalkTcGY=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "165b1650b753316aa7f1787f3005a8d2da0f5301",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix_2": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression_2"
+      },
+      "locked": {
+        "lastModified": 1712911606,
+        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "devenv-2.21",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692808169,
+        "narHash": "sha256-x9Opq06rIiwdwGeK2Ykj69dNc2IvUH1fY55Wm7atwrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9201b5ff357e781bf014d0330d18555695df7ba8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression_2": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1710695816,
+        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1710796454,
+        "narHash": "sha256-lQlICw60RhH8sHTDD/tJiiJrlAfNn8FDI9c+7G2F0SE=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "06fb0f1c643aee3ae6838dda3b37ef0abc3c763b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1713537308,
+        "narHash": "sha256-XtTSSIB2DA6tOv+l0FhvfDMiyCmhoRbNB+0SeInZkbk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5c24cf2f0a12ad855f444c30b2421d044120c66f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1713564160,
+        "narHash": "sha256-YguPZpiejgzLEcO36/SZULjJQ55iWcjAmf3lYiyV1Fo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bc194f70731cc5d2b046a6c1b3b15f170f05999c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "devenv",
+          "cachix",
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1692876271,
+        "narHash": "sha256-IXfZEkI0Mal5y1jr6IRWMqK8GW2/f28xJenZIPQqkY0=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "d5006be9c2c2417dafb2e2e5034d83fabd207ee3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1712897695,
+        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs_4",
+        "systems": "systems_3"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1713628977,
+        "narHash": "sha256-iN5QUlUq527lswmBC+RopfXdu6Xx7mmTaBSH2l59FtM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "55d9a533b309119c8acd13061581b43ae8840823",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,106 @@
 {
-  description = "PINCE build and run";
-
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    systems.url = "github:nix-systems/default";
+    devenv.url = "github:cachix/devenv";
+    fenix.url = "github:nix-community/fenix";
   };
 
-  outputs = { self, nixpkgs }: { };
+  nixConfig = {
+    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
+    extra-substituters = "https://devenv.cachix.org";
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , devenv
+    , systems
+    , ...
+    } @ inputs:
+    let
+      forEachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      packages = forEachSystem (system: {
+        devenv-up = self.devShells.${system}.default.config.procfileScript;
+      });
+
+      devShells =
+        forEachSystem
+          (system:
+            let
+              pkgs = nixpkgs.legacyPackages.${system};
+            in
+            {
+              default = devenv.lib.mkShell {
+                inherit inputs pkgs;
+                modules = [
+                  {
+                    scripts.build-libscanmem.exec = ''
+                      compile_libscanmem() {
+                        sh autogen.sh
+                        ./configure --prefix="$(pwd)"
+                        make -j"$NUM_MAKE_JOBS"
+                        return 0
+                      }
+
+                      echo "[i] Downloading libscanmem"
+                      git submodule update --init --recursive
+
+                      echo "[i] Compiling libscanmem"
+                      if [ ! -d "libpince/libscanmem" ]; then
+                          mkdir libpince/libscanmem
+                      fi
+                      cd libscanmem-PINCE
+                      if [ -d "./.libs" ]; then
+                          echo "[*] Artifacts found, recompile anyway ? [y/n] "
+                          read -r answer
+                          if echo "$answer" | grep -iq "^[Yy]"; then
+                              compile_libscanmem
+                          fi
+                      else
+                          compile_libscanmem
+                      fi
+
+                      echo "[i] Copying libscanmem artifacts to libpince"
+                      cp --preserve .libs/libscanmem.so ../libpince/libscanmem/
+                      cp --preserve wrappers/scanmem.py ../libpince/libscanmem
+                    '';
+
+                    scripts.pince.exec = ''
+                      sudo -E PYTHONPATH=$PYTHONPATH PYTHONDONTWRITEBYTECODE=1 ./PINCE.py
+                    '';
+
+                    languages = {
+                      c.enable = true;
+
+                      python = {
+                        enable = true;
+                        venv = {
+                          enable = true;
+                          requirements = builtins.readFile ./requirements.txt;
+                        };
+                      };
+                    };
+
+                    packages = with pkgs; [
+                      # PINCE
+                      gdb
+                      libtool
+                      cairo
+                      gobject-introspection
+                      qt6.qttools
+                      python311Packages.pyqt6
+                      gtk3
+
+                      # libscanmem
+                      automake
+                      autoconf
+                    ];
+                  }
+                ];
+              };
+            });
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,9 @@
+{
+  description = "PINCE build and run";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+  };
+
+  outputs = { self, nixpkgs }: { };
+}

--- a/libpince/typedefs.py
+++ b/libpince/typedefs.py
@@ -18,14 +18,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # IMPORTANT: Any constant involving only PINCE.py should be declared in PINCE.py
 
-import collections.abc, queue, sys
+import collections.abc, queue, sys, shutil
+
 
 class CONST_TIME:
     GDB_INPUT_SLEEP = sys.float_info.min
 
 
 class PATHS:
-    GDB = "/bin/gdb"
+    GDB = shutil.which("gdb") or "/bin/gdb"
     TMP = "/tmp/PINCE/"  # Use utils.get_tmp_path()
     IPC = "/dev/shm/PINCE_IPC/"  # Use utils.get_ipc_path()
     FROM_PINCE = "/from_PINCE"  # Use utils.get_from_pince_file()
@@ -49,7 +50,12 @@ class USER_PATHS:
 
     @staticmethod
     def get_init_files():
-        return USER_PATHS.GDBINIT, USER_PATHS.GDBINIT_AA, USER_PATHS.PINCEINIT, USER_PATHS.PINCEINIT_AA
+        return (
+            USER_PATHS.GDBINIT,
+            USER_PATHS.GDBINIT_AA,
+            USER_PATHS.PINCEINIT,
+            USER_PATHS.PINCEINIT_AA,
+        )
 
 
 class INFERIOR_STATUS:
@@ -128,8 +134,25 @@ class TOGGLE_ATTACH:
 
 class REGISTERS:
     GENERAL_32 = ["eax", "ebx", "ecx", "edx", "esi", "edi", "ebp", "esp", "eip"]
-    GENERAL_64 = ["rax", "rbx", "rcx", "rdx", "rsi", "rdi", "rbp", "rsp", "rip", "r8", "r9", "r10", "r11", "r12",
-                  "r13", "r14", "r15"]
+    GENERAL_64 = [
+        "rax",
+        "rbx",
+        "rcx",
+        "rdx",
+        "rsi",
+        "rdi",
+        "rbp",
+        "rsp",
+        "rip",
+        "r8",
+        "r9",
+        "r10",
+        "r11",
+        "r12",
+        "r13",
+        "r14",
+        "r15",
+    ]
     SEGMENT = ["cs", "ss", "ds", "es", "fs", "gs"]
     FLAG = ["cf", "pf", "af", "zf", "sf", "tf", "if", "df", "of"]
 
@@ -210,78 +233,86 @@ on_hit_to_text_dict = {
     BREAKPOINT_ON_HIT.BREAK: "Break",
     BREAKPOINT_ON_HIT.FIND_CODE: "Find Code",
     BREAKPOINT_ON_HIT.FIND_ADDR: "Find Address",
-    BREAKPOINT_ON_HIT.TRACE: "Trace"
+    BREAKPOINT_ON_HIT.TRACE: "Trace",
 }
 
 # Represents the texts at indexes in the address table
 # TODO: This class is mostly an UI helper, maybe integrate it into the the UI completely in the future?
-index_to_text_dict = collections.OrderedDict([
-    (VALUE_INDEX.INT8, "Int8"),
-    (VALUE_INDEX.INT16, "Int16"),
-    (VALUE_INDEX.INT32, "Int32"),
-    (VALUE_INDEX.INT64, "Int64"),
-    (VALUE_INDEX.FLOAT32, "Float32"),
-    (VALUE_INDEX.FLOAT64, "Float64"),
-    (VALUE_INDEX.STRING_ASCII, "String_ASCII"),
-    (VALUE_INDEX.STRING_UTF8, "String_UTF8"),
-    (VALUE_INDEX.STRING_UTF16, "String_UTF16"),
-    (VALUE_INDEX.STRING_UTF32, "String_UTF32"),
-    (VALUE_INDEX.AOB, "ByteArray")
-])
+index_to_text_dict = collections.OrderedDict(
+    [
+        (VALUE_INDEX.INT8, "Int8"),
+        (VALUE_INDEX.INT16, "Int16"),
+        (VALUE_INDEX.INT32, "Int32"),
+        (VALUE_INDEX.INT64, "Int64"),
+        (VALUE_INDEX.FLOAT32, "Float32"),
+        (VALUE_INDEX.FLOAT64, "Float64"),
+        (VALUE_INDEX.STRING_ASCII, "String_ASCII"),
+        (VALUE_INDEX.STRING_UTF8, "String_UTF8"),
+        (VALUE_INDEX.STRING_UTF16, "String_UTF16"),
+        (VALUE_INDEX.STRING_UTF32, "String_UTF32"),
+        (VALUE_INDEX.AOB, "ByteArray"),
+    ]
+)
 
 text_to_index_dict = collections.OrderedDict()
 for key in index_to_text_dict:
     text_to_index_dict[index_to_text_dict[key]] = key
 
-scanmem_result_to_index_dict = collections.OrderedDict([
-    ("I8", VALUE_INDEX.INT8),
-    ("I8u", VALUE_INDEX.INT8),
-    ("I8s", VALUE_INDEX.INT8),
-    ("I16", VALUE_INDEX.INT16),
-    ("I16u", VALUE_INDEX.INT16),
-    ("I16s", VALUE_INDEX.INT16),
-    ("I32", VALUE_INDEX.INT32),
-    ("I32u", VALUE_INDEX.INT32),
-    ("I32s", VALUE_INDEX.INT32),
-    ("I64", VALUE_INDEX.INT64),
-    ("I64u", VALUE_INDEX.INT64),
-    ("I64s", VALUE_INDEX.INT64),
-    ("F32", VALUE_INDEX.FLOAT32),
-    ("F64", VALUE_INDEX.FLOAT64),
-    ("string", VALUE_INDEX.STRING_UTF8),
-    ("bytearray", VALUE_INDEX.AOB)
-])
+scanmem_result_to_index_dict = collections.OrderedDict(
+    [
+        ("I8", VALUE_INDEX.INT8),
+        ("I8u", VALUE_INDEX.INT8),
+        ("I8s", VALUE_INDEX.INT8),
+        ("I16", VALUE_INDEX.INT16),
+        ("I16u", VALUE_INDEX.INT16),
+        ("I16s", VALUE_INDEX.INT16),
+        ("I32", VALUE_INDEX.INT32),
+        ("I32u", VALUE_INDEX.INT32),
+        ("I32s", VALUE_INDEX.INT32),
+        ("I64", VALUE_INDEX.INT64),
+        ("I64u", VALUE_INDEX.INT64),
+        ("I64s", VALUE_INDEX.INT64),
+        ("F32", VALUE_INDEX.FLOAT32),
+        ("F64", VALUE_INDEX.FLOAT64),
+        ("string", VALUE_INDEX.STRING_UTF8),
+        ("bytearray", VALUE_INDEX.AOB),
+    ]
+)
 
 # Represents the texts at indexes in scan combobox
 # TODO: Same as index_to_text_dict, consider integrating into UI completely
-scan_index_to_text_dict = collections.OrderedDict([
-    (SCAN_INDEX.INT_ANY, "Int(any)"),
-    (SCAN_INDEX.INT8, "Int8"),
-    (SCAN_INDEX.INT16, "Int16"),
-    (SCAN_INDEX.INT32, "Int32"),
-    (SCAN_INDEX.INT64, "Int64"),
-    (SCAN_INDEX.FLOAT_ANY, "Float(any)"),
-    (SCAN_INDEX.FLOAT32, "Float32"),
-    (SCAN_INDEX.FLOAT64, "Float64"),
-    (SCAN_INDEX.ANY, "Any(int, float)"),
-    (SCAN_INDEX.STRING, "String"),
-    (VALUE_INDEX.AOB, "ByteArray")
-])
+scan_index_to_text_dict = collections.OrderedDict(
+    [
+        (SCAN_INDEX.INT_ANY, "Int(any)"),
+        (SCAN_INDEX.INT8, "Int8"),
+        (SCAN_INDEX.INT16, "Int16"),
+        (SCAN_INDEX.INT32, "Int32"),
+        (SCAN_INDEX.INT64, "Int64"),
+        (SCAN_INDEX.FLOAT_ANY, "Float(any)"),
+        (SCAN_INDEX.FLOAT32, "Float32"),
+        (SCAN_INDEX.FLOAT64, "Float64"),
+        (SCAN_INDEX.ANY, "Any(int, float)"),
+        (SCAN_INDEX.STRING, "String"),
+        (VALUE_INDEX.AOB, "ByteArray"),
+    ]
+)
 
 # Used in scan_data_type option of scanmem
-scan_index_to_scanmem_dict = collections.OrderedDict([
-    (SCAN_INDEX.INT_ANY, "int"),
-    (SCAN_INDEX.INT8, "int8"),
-    (SCAN_INDEX.INT16, "int16"),
-    (SCAN_INDEX.INT32, "int32"),
-    (SCAN_INDEX.INT64, "int64"),
-    (SCAN_INDEX.FLOAT_ANY, "float"),
-    (SCAN_INDEX.FLOAT32, "float32"),
-    (SCAN_INDEX.FLOAT64, "float64"),
-    (SCAN_INDEX.ANY, "number"),
-    (SCAN_INDEX.STRING, "string"),
-    (VALUE_INDEX.AOB, "bytearray")
-])
+scan_index_to_scanmem_dict = collections.OrderedDict(
+    [
+        (SCAN_INDEX.INT_ANY, "int"),
+        (SCAN_INDEX.INT8, "int8"),
+        (SCAN_INDEX.INT16, "int16"),
+        (SCAN_INDEX.INT32, "int32"),
+        (SCAN_INDEX.INT64, "int64"),
+        (SCAN_INDEX.FLOAT_ANY, "float"),
+        (SCAN_INDEX.FLOAT32, "float32"),
+        (SCAN_INDEX.FLOAT64, "float64"),
+        (SCAN_INDEX.ANY, "number"),
+        (SCAN_INDEX.STRING, "string"),
+        (VALUE_INDEX.AOB, "bytearray"),
+    ]
+)
 
 
 # TODO: Same as index_to_text_dict, consider integrating into UI completely
@@ -301,11 +332,26 @@ class SCAN_TYPE:
     @staticmethod
     def get_list(scan_mode):
         if scan_mode == SCAN_MODE.NEW:
-            return [SCAN_TYPE.EXACT, SCAN_TYPE.LESS, SCAN_TYPE.MORE, SCAN_TYPE.BETWEEN, SCAN_TYPE.UNKNOWN]
+            return [
+                SCAN_TYPE.EXACT,
+                SCAN_TYPE.LESS,
+                SCAN_TYPE.MORE,
+                SCAN_TYPE.BETWEEN,
+                SCAN_TYPE.UNKNOWN,
+            ]
         else:
-            return [SCAN_TYPE.EXACT, SCAN_TYPE.INCREASED, SCAN_TYPE.INCREASED_BY, SCAN_TYPE.DECREASED,
-                    SCAN_TYPE.DECREASED_BY, SCAN_TYPE.LESS, SCAN_TYPE.MORE, SCAN_TYPE.BETWEEN,
-                    SCAN_TYPE.CHANGED, SCAN_TYPE.UNCHANGED]
+            return [
+                SCAN_TYPE.EXACT,
+                SCAN_TYPE.INCREASED,
+                SCAN_TYPE.INCREASED_BY,
+                SCAN_TYPE.DECREASED,
+                SCAN_TYPE.DECREASED_BY,
+                SCAN_TYPE.LESS,
+                SCAN_TYPE.MORE,
+                SCAN_TYPE.BETWEEN,
+                SCAN_TYPE.CHANGED,
+                SCAN_TYPE.UNCHANGED,
+            ]
 
 
 class SCAN_MODE:
@@ -319,10 +365,12 @@ class SCAN_SCOPE:
     FULL_RW = 3
     FULL = 4
 
+
 class ENDIANNESS:
     HOST = 0
     LITTLE = 1
     BIG = 2
+
 
 string_index_to_encoding_dict = {
     VALUE_INDEX.STRING_UTF8: ["utf-8", "surrogateescape"],
@@ -350,7 +398,7 @@ index_to_valuetype_dict = {
     VALUE_INDEX.STRING_UTF8: [None, None],
     VALUE_INDEX.STRING_UTF16: [None, None],
     VALUE_INDEX.STRING_UTF32: [None, None],
-    VALUE_INDEX.AOB: [None, None]
+    VALUE_INDEX.AOB: [None, None],
 }
 
 # Check gdbutils for an exemplary usage
@@ -360,43 +408,54 @@ index_to_struct_pack_dict = {
     VALUE_INDEX.INT32: "I",
     VALUE_INDEX.INT64: "Q",
     VALUE_INDEX.FLOAT32: "f",
-    VALUE_INDEX.FLOAT64: "d"
+    VALUE_INDEX.FLOAT64: "d",
 }
 
 # Format: {tag:tag_description}
-tag_to_string = collections.OrderedDict([
-    ("MemoryRW", "Memory Read/Write"),
-    ("ValueType", "Value Type"),
-    ("Injection", "Injection"),
-    ("Debug", "Debugging"),
-    ("BreakWatchpoints", "Breakpoints&Watchpoints"),
-    ("Threads", "Threads"),
-    ("Registers", "Registers"),
-    ("Stack", "Stack&StackTrace"),
-    ("Assembly", "Disassemble&Assemble"),
-    ("GDBExpressions", "GDB Expressions"),
-    ("GDBCommunication", "GDB Communication"),
-    ("Tools", "Tools"),
-    ("Utilities", "Utilities"),
-    ("Processes", "Processes"),
-    ("GUI", "GUI"),
-    ("ConditionsLocks", "Conditions&Locks"),
-    ("GDBInformation", "GDB Information"),
-    ("InferiorInformation", "Inferior Information"),
-])
+tag_to_string = collections.OrderedDict(
+    [
+        ("MemoryRW", "Memory Read/Write"),
+        ("ValueType", "Value Type"),
+        ("Injection", "Injection"),
+        ("Debug", "Debugging"),
+        ("BreakWatchpoints", "Breakpoints&Watchpoints"),
+        ("Threads", "Threads"),
+        ("Registers", "Registers"),
+        ("Stack", "Stack&StackTrace"),
+        ("Assembly", "Disassemble&Assemble"),
+        ("GDBExpressions", "GDB Expressions"),
+        ("GDBCommunication", "GDB Communication"),
+        ("Tools", "Tools"),
+        ("Utilities", "Utilities"),
+        ("Processes", "Processes"),
+        ("GUI", "GUI"),
+        ("ConditionsLocks", "Conditions&Locks"),
+        ("GDBInformation", "GDB Information"),
+        ("InferiorInformation", "Inferior Information"),
+    ]
+)
 
 # size-->int, any other field-->str
-tuple_breakpoint_info = collections.namedtuple("tuple_breakpoint_info", "number breakpoint_type \
-                                                disp enabled address size on_hit hit_count enable_count condition")
+tuple_breakpoint_info = collections.namedtuple(
+    "tuple_breakpoint_info",
+    "number breakpoint_type \
+                                                disp enabled address size on_hit hit_count enable_count condition",
+)
 
 # start, end-->int, perms-->str, file_name-->str
-tuple_region_info = collections.namedtuple("tuple_region_info", "start end perms file_name")
+tuple_region_info = collections.namedtuple(
+    "tuple_region_info", "start end perms file_name"
+)
 
 # all fields-->str/None
-tuple_examine_expression = collections.namedtuple("tuple_examine_expression", "all address symbol")
+tuple_examine_expression = collections.namedtuple(
+    "tuple_examine_expression", "all address symbol"
+)
 
 # all fields-->bool
-gdb_output_mode = collections.namedtuple("gdb_output_mode", "async_output command_output command_info")
+gdb_output_mode = collections.namedtuple(
+    "gdb_output_mode", "async_output command_output command_info"
+)
 
 
 class GDBInitializeException(Exception):
@@ -412,8 +471,14 @@ class Frozen:
 
 
 class ValueType:
-    def __init__(self, value_index=VALUE_INDEX.INT32, length=10, zero_terminate=True,
-                 value_repr=VALUE_REPR.UNSIGNED, endian=ENDIANNESS.HOST):
+    def __init__(
+        self,
+        value_index=VALUE_INDEX.INT32,
+        length=10,
+        zero_terminate=True,
+        value_repr=VALUE_REPR.UNSIGNED,
+        endian=ENDIANNESS.HOST,
+    ):
         """
         Args:
             value_index (int): Determines the type of data. Can be a member of VALUE_INDEX
@@ -430,7 +495,13 @@ class ValueType:
         self.endian = endian
 
     def serialize(self):
-        return self.value_index, self.length, self.zero_terminate, self.value_repr, self.endian
+        return (
+            self.value_index,
+            self.length,
+            self.zero_terminate,
+            self.value_repr,
+            self.endian,
+        )
 
     def text(self):
         """Returns the text representation according to its members
@@ -499,7 +570,11 @@ class PointerChainRequest:
         """
         Returns the text representation of this pointer's base address
         """
-        return hex(self.base_address) if type(self.base_address) != str else self.base_address
+        return (
+            hex(self.base_address)
+            if type(self.base_address) != str
+            else self.base_address
+        )
 
 
 class RegisterQueue:
@@ -537,4 +612,3 @@ class KeyboardModifiersTupleDict(collections.abc.Mapping):
 
     def __len__(self):
         return len(self._storage)
-


### PR DESCRIPTION
* Created a Nix Flake (easy reproducible environment) allowing to build `libscanmem` and run `pince`
* Updated README
* Added small auto path resolving for GDB in [libpince/typedefs.py](https://github.com/korcankaraokcu/PINCE/compare/master...standard3:PINCE:feat/nix-flake?expand=1#diff-587ea0cb8391352297edfcae16fadb57c20266686cdc7cc9813ba91ca85a6745) as paths are different with Nix and formatted the file according to PEP-8