### PR TITLE
Fixed `get_list()` to not show incompatible scan type options

### DIFF
--- a/libpince/typedefs.py
+++ b/libpince/typedefs.py
@@ -333,31 +333,42 @@ class SCAN_TYPE:
     @staticmethod
     def get_list(scan_mode, value_type):
         if scan_mode == SCAN_MODE.NEW:
-            list = [
-                SCAN_TYPE.EXACT,
-                SCAN_TYPE.NOT,
-                SCAN_TYPE.LESS,
-                SCAN_TYPE.MORE,
-                SCAN_TYPE.BETWEEN,
-                SCAN_TYPE.UNKNOWN,
-            ]
-        else:
-            list = [
-                SCAN_TYPE.EXACT,
-                SCAN_TYPE.NOT,
-                SCAN_TYPE.INCREASED,
-                SCAN_TYPE.INCREASED_BY,
-                SCAN_TYPE.DECREASED,
-                SCAN_TYPE.DECREASED_BY,
-                SCAN_TYPE.LESS,
-                SCAN_TYPE.MORE,
-                SCAN_TYPE.BETWEEN,
-                SCAN_TYPE.CHANGED,
-                SCAN_TYPE.UNCHANGED,
-            ]
+            if value_type != SCAN_INDEX.AOB and value_type != SCAN_INDEX.STRING:
+                list = [
+                    SCAN_TYPE.EXACT,
+                    SCAN_TYPE.NOT,
+                    SCAN_TYPE.LESS,
+                    SCAN_TYPE.MORE,
+                    SCAN_TYPE.BETWEEN,
+                    SCAN_TYPE.UNKNOWN,
+                ]
+            else:
+                list = [
+                    SCAN_TYPE.EXACT,
+                    SCAN_TYPE.UNKNOWN,
+                ]
 
-        if value_type == SCAN_INDEX.AOB or value_type == SCAN_INDEX.STRING:
-            del list[1]
+        else:
+            if value_type != SCAN_INDEX.AOB and value_type != SCAN_INDEX.STRING:
+                list = [
+                    SCAN_TYPE.EXACT,
+                    SCAN_TYPE.NOT,
+                    SCAN_TYPE.INCREASED,
+                    SCAN_TYPE.INCREASED_BY,
+                    SCAN_TYPE.DECREASED,
+                    SCAN_TYPE.DECREASED_BY,
+                    SCAN_TYPE.LESS,
+                    SCAN_TYPE.MORE,
+                    SCAN_TYPE.BETWEEN,
+                    SCAN_TYPE.CHANGED,
+                    SCAN_TYPE.UNCHANGED,
+                ]
+            else:
+                list = [
+                    SCAN_TYPE.EXACT,
+                    SCAN_TYPE.CHANGED,
+                    SCAN_TYPE.UNCHANGED,
+                ]
 
         return list
 

--- a/libpince/typedefs.py
+++ b/libpince/typedefs.py
@@ -333,7 +333,9 @@ class SCAN_TYPE:
     @staticmethod
     def get_list(scan_mode, value_type):
         if scan_mode == SCAN_MODE.NEW:
-            if value_type != SCAN_INDEX.AOB and value_type != SCAN_INDEX.STRING:
+            if value_type == SCAN_INDEX.AOB or value_type == SCAN_INDEX.STRING:
+                list = [SCAN_TYPE.EXACT]
+            else:
                 list = [
                     SCAN_TYPE.EXACT,
                     SCAN_TYPE.NOT,
@@ -342,14 +344,11 @@ class SCAN_TYPE:
                     SCAN_TYPE.BETWEEN,
                     SCAN_TYPE.UNKNOWN,
                 ]
-            else:
-                list = [
-                    SCAN_TYPE.EXACT,
-                    SCAN_TYPE.UNKNOWN,
-                ]
 
         else:
-            if value_type != SCAN_INDEX.AOB and value_type != SCAN_INDEX.STRING:
+            if value_type == SCAN_INDEX.AOB or value_type == SCAN_INDEX.STRING:
+                list = [SCAN_TYPE.EXACT]
+            else:
                 list = [
                     SCAN_TYPE.EXACT,
                     SCAN_TYPE.NOT,
@@ -360,12 +359,6 @@ class SCAN_TYPE:
                     SCAN_TYPE.LESS,
                     SCAN_TYPE.MORE,
                     SCAN_TYPE.BETWEEN,
-                    SCAN_TYPE.CHANGED,
-                    SCAN_TYPE.UNCHANGED,
-                ]
-            else:
-                list = [
-                    SCAN_TYPE.EXACT,
                     SCAN_TYPE.CHANGED,
                     SCAN_TYPE.UNCHANGED,
                 ]


### PR DESCRIPTION
- `String` or `AOB` value types when selected will not show incompatible scan types as a option