### PR TITLE
fix SIGSEGV when using `nextscan_hotkey_pressed` while already scanning

### DIFF
--- a/PINCE.py
+++ b/PINCE.py
@@ -431,6 +431,8 @@ class MainForm(QMainWindow, MainWindow):
         self.flashAttachButtonTimer.start(100)
         guiutils.center(self)
 
+        self.is_scanning = False
+
     def settings_changed(self):
         if states.auto_attach:
             self.auto_attach_timer.start(100)
@@ -496,7 +498,7 @@ class MainForm(QMainWindow, MainWindow):
 
     @utils.ignore_exceptions
     def nextscan_hotkey_pressed(self, index):
-        if self.scan_mode == typedefs.SCAN_MODE.NEW:
+        if self.scan_mode == typedefs.SCAN_MODE.NEW or self.is_scanning:
             return
         self.comboBox_ScanType.setCurrentIndex(index)
         self.pushButton_NextScan.clicked.emit()
@@ -985,6 +987,7 @@ class MainForm(QMainWindow, MainWindow):
     def scan_values(self):
         if debugcore.currentpid == -1:
             return
+        self.is_scanning = True
         search_for = self.validate_search(self.lineEdit_Scan.text(), self.lineEdit_Scan2.text())
         self.QWidget_Toolbox.setEnabled(False)
         self.progressBar.setValue(0)
@@ -1218,6 +1221,7 @@ class MainForm(QMainWindow, MainWindow):
             self.deleted_regions.extend(scan_regions_dialog.get_values())
 
     def scan_callback(self):
+        self.is_scanning = False
         self.progress_bar_timer.stop()
         self.progressBar.setValue(100)
         matches = scanmem.matches()

--- a/PINCE.py
+++ b/PINCE.py
@@ -429,9 +429,9 @@ class MainForm(QMainWindow, MainWindow):
         self.flashAttachButtonTimer.timeout.connect(self.flash_attach_button)
         self.flashAttachButton_gradiantState = 0
         self.flashAttachButtonTimer.start(100)
-        guiutils.center(self)
-
         self.is_scanning = False
+
+        guiutils.center(self)
 
     def settings_changed(self):
         if states.auto_attach:

--- a/PINCE.py
+++ b/PINCE.py
@@ -987,7 +987,6 @@ class MainForm(QMainWindow, MainWindow):
     def scan_values(self):
         if debugcore.currentpid == -1:
             return
-        self.is_scanning = True
         search_for = self.validate_search(self.lineEdit_Scan.text(), self.lineEdit_Scan2.text())
         self.QWidget_Toolbox.setEnabled(False)
         self.progressBar.setValue(0)
@@ -996,6 +995,7 @@ class MainForm(QMainWindow, MainWindow):
         scan_thread = guitypedefs.Worker(scanmem.send_command, search_for)
         scan_thread.signals.finished.connect(self.scan_callback)
         states.threadpool.start(scan_thread)
+        self.is_scanning = True
 
     def resize_address_table(self):
         self.treeWidget_AddressTable.resizeColumnToContents(FROZEN_COL)


### PR DESCRIPTION
while scanning, you can cause a segmentation fault if you use use a nextscan hotkey while already scanning, this pr should fix that by adding a boolean flag `self.is_scanning` that is checked before scanning in `nextscan_hotkey_pressed`