### PR TITLE
Change pygobject version to 3.50.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ capstone==5.0.6
 keystone-engine==0.9.2
 pygdbmi==0.11.0.0
 keyboard==0.13.5
-pygobject==3.54.5
+pygobject==3.50.0


### PR DESCRIPTION
Debian 12 doesn't support pygobject>3.50.0 and with this version PINCE works fine.
[Similar issue](https://github.com/beeware/toga/issues/3143)