### PR TITLE
Fix f-string for Python older than 3.12

### DIFF
--- a/libpince/debugcore.py
+++ b/libpince/debugcore.py
@@ -1858,7 +1858,7 @@ def track_breakpoint(expression, register_expressions) -> int | None:
         return
     # TODO (lldb): When we switch to LLDB, remove c& and only continue if there isn't an active trace
     # Apply the same for track_watchpoint
-    send_command(f"commands {breakpoint}\npince-get-track-breakpoint-info {register_expressions.replace(" ", "")},{breakpoint}\nc&\nend")
+    send_command(f"commands {breakpoint}\npince-get-track-breakpoint-info {register_expressions.replace(' ', '')},{breakpoint}\nc&\nend")
     return breakpoint
 
 


### PR DESCRIPTION
With the newest commit, there is an error, as python can't determine when quotes are inside expressions, or in normal case.
`Traceback (most recent call last):
  File "/home/vanello/Applications/Pince/PINCE/PINCE.py", line 85, in <module>
    from GUI.AbstractTableModels.AsciiModel import QAsciiModel
  File "/home/vanello/Applications/Pince/PINCE/GUI/AbstractTableModels/AsciiModel.py", line 18, in <module>
    from GUI.AbstractTableModels.HexModel import QHexModel
  File "/home/vanello/Applications/Pince/PINCE/GUI/AbstractTableModels/HexModel.py", line 20, in <module>
    from libpince import utils, debugcore
  File "/home/vanello/Applications/Pince/PINCE/libpince/debugcore.py", line 1861
    send_command(f"commands {breakpoint}\npince-get-track-breakpoint-info {register_expressions.replace(" ", "")},{breakpoint}\nc&\nend")
`
Using different quotes helps