### PR TITLE
Verify PINCE.py existence in PINCE.sh

### DIFF
--- a/PINCE.sh
+++ b/PINCE.sh
@@ -32,7 +32,8 @@ PYTHON="${SCRIPTDIR}/.venv/bin/python3"
 PINCE_PY="${SCRIPTDIR}/PINCE.py"
 
 if [ ! -f "$PINCE_PY" ]; then
-    echo "Error: PINCE.py not found in ${SCRIPTDIR}. Please make sure you are running this script from the project root."
+    echo "Error: PINCE.py not found in ${SCRIPTDIR}."
+    echo "Make sure you are running PINCE.sh from the project root directory."
     exit 1
 fi
 

--- a/PINCE.sh
+++ b/PINCE.sh
@@ -31,6 +31,11 @@ fi
 PYTHON="${SCRIPTDIR}/.venv/bin/python3"
 PINCE_PY="${SCRIPTDIR}/PINCE.py"
 
+if [ ! -f "$PINCE_PY" ]; then
+    echo "Error: PINCE.py not found in ${SCRIPTDIR}. Please make sure you are running this script from the project root."
+    exit 1
+fi
+
 if type pkexec &> /dev/null; then
 	# Preserve env vars to keep settings like theme preferences.
 	# Pkexec does not support passing all of env via a flag like `-E` so we need to


### PR DESCRIPTION
Just a small fix to handle missing PINCE.py file. It provides a clearer error message for the user before calling pkexec/sudo.