### PR TITLE
Make AppImage updateable via external tools

### DIFF
--- a/.github/workflows/release_appimage.yml
+++ b/.github/workflows/release_appimage.yml
@@ -22,4 +22,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           make_latest: true
-          files: ci/PINCE-x86_64.AppImage
+          files: |
+            ci/PINCE-x86_64.AppImage
+            ci/PINCE-x86_64.AppImage.zsync

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -191,4 +191,5 @@ patchelf --add-rpath "\$ORIGIN/../../../../../../" AppDir/usr/conda/lib/python3.
 # Package AppDir into AppImage
 LD_LIBRARY_PATH="$(readlink -f ./AppDir/usr/conda/lib)"
 export LD_LIBRARY_PATH
+export UPDATE_INFORMATION="gh-releases-zsync|korcankaraokcu|PINCE|latest|PINCE-x86_64.AppImage.zsync"
 $DEPLOYTOOL --icon-file PINCE.png --appdir AppDir/ --output appimage --custom-apprun AppRun.sh || exit_on_failure

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -29,7 +29,7 @@ cd "$PACKAGEDIR" || exit
 cleanup () {
 	cd "$PACKAGEDIR" || return
 	# Remove everything outside of package.sh and AppImage output
-	find ! -iname "package.sh" ! -iname "PINCE*.AppImage" -delete
+	find ! -iname "package.sh" ! -iname "PINCE*.AppImage" ! -iname "PINCE*.zsync" -delete
 }
 trap cleanup EXIT
 
@@ -191,5 +191,5 @@ patchelf --add-rpath "\$ORIGIN/../../../../../../" AppDir/usr/conda/lib/python3.
 # Package AppDir into AppImage
 LD_LIBRARY_PATH="$(readlink -f ./AppDir/usr/conda/lib)"
 export LD_LIBRARY_PATH
-export UPDATE_INFORMATION="gh-releases-zsync|korcankaraokcu|PINCE|latest|PINCE-x86_64.AppImage.zsync"
+export LDAI_UPDATE_INFORMATION="gh-releases-zsync|korcankaraokcu|PINCE|latest|PINCE-x86_64.AppImage.zsync"
 $DEPLOYTOOL --icon-file PINCE.png --appdir AppDir/ --output appimage --custom-apprun AppRun.sh || exit_on_failure


### PR DESCRIPTION
Closes #337 

Can be adjusted to e.g. `latest-all` instead of `latest` to also include eventual pre-releases.

I didn't test if it actually works.