### PR TITLE
fix: replace bare except with re.error in auto_attach_loop

### DIFF
--- a/PINCE.py
+++ b/PINCE.py
@@ -430,7 +430,7 @@ class MainForm(QMainWindow, MainWindow):
         if states.auto_attach_regex:
             try:
                 compiled_re = re.compile(states.auto_attach)
-            except:
+            except re.error:
                 logger.exception(f"Auto-attach failed: {states.auto_attach} isn't a valid regex")
                 return
             for pid, _, name in utils.get_process_list():


### PR DESCRIPTION
## Bug
The bare `except:` clause in `auto_attach_loop` would swallow all exceptions, including `KeyboardInterrupt` and `SystemExit`. Since `re.compile()` only raises `re.error` for invalid regex patterns, narrowing the exception type prevents accidental masking of unrelated errors.

## Fix
Changed `except:` to `except re.error:` so only the actual regex compilation error is caught.

## Before
```python
try:
    compiled_re = re.compile(states.auto_attach)
except:
    logger.exception(...)
    return
```

## After
```python
try:
    compiled_re = re.compile(states.auto_attach)
except re.error:
    logger.exception(...)
    return
```

— Sent via @AmSach bot