### PR TITLE
Fix minor spellings errors

### DIFF
--- a/ci/package.sh
+++ b/ci/package.sh
@@ -33,7 +33,7 @@ trap cleanup EXIT
 # Error checking function
 exit_on_failure() {
 	echo
-	echo "Error occured while creating AppImage! Check the log above!"
+	echo "Error occurred while creating AppImage! Check the log above!"
 	exit 1
 }
 cleanup || exit_on_failure

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 exit_on_error() {
 	echo
-	echo "Error occured while installing PINCE, check the output above for more information"
+	echo "Error occurred while installing PINCE, check the output above for more information"
 	echo "Installation failed."
 	exit 1
 }

--- a/libpince/debugcore.py
+++ b/libpince/debugcore.py
@@ -534,7 +534,7 @@ def set_interrupt_signal(signal_name: str) -> None:
 
 
 def handle_signal(signal_name: str, stop: bool, pass_to_program: bool) -> None:
-    """Decides on what will GDB do when the process recieves a signal
+    """Decides on what will GDB do when the process receives a signal
 
     Args:
         signal_name (str): Name of the signal


### PR DESCRIPTION
Correct spelling error in install.sh user-facing error message shown when PINCE installation fails.

## Change
- `install.sh` line 21: `Error occured while installing PINCE` -> `Error occurred while installing PINCE`

## Testing
- Verified fix with `grep -n 'Error occurred' install.sh`
- No functional logic changes, only user-facing string correction