### PR TITLE
install.sh: Add support for doas (and potentially other privelege escalation tools)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -111,6 +111,20 @@ ask_pkg_mgr() {
 	return 0
 }
 
+detect_sudo() {
+	# prefer `doas` if available
+	if type doas &>/dev/null; then
+		SUDO="doas"
+		echo "Using doas for installation"
+	elif type sudo &>/dev/null; then
+		SUDO="sudo"
+	else
+		return 1
+	fi
+
+	return 0
+}
+
 # About xcb packages -> https://github.com/cdgriffith/FastFlix/wiki/Common-questions-and-problems
 PKG_NAMES_ALL="python3-pip gdb"
 PKG_NAMES_DEBIAN="$PKG_NAMES_ALL python3-dev python3-venv qt6-l10n-tools libxcb-randr0 libxcb-shape0 libxcb-xkb1 libxcb-cursor0"
@@ -175,6 +189,12 @@ main() {
 		exit 1
 	fi
 
+	if ! detect_sudo; then
+		echo
+		echo "No supported privelege escalation tool like sudo or doas found!"
+		exit 1
+	fi
+
 	if [ -r /etc/os-release ]; then
 		. /etc/os-release
 		OS_NAME="$ID $ID_LIKE"
@@ -190,7 +210,7 @@ main() {
 		set_install_vars "$OS_NAME"
 	fi
 
-	sudo ${PKG_MGR} ${INSTALL_COMMAND} ${PKG_NAMES} || exit_on_error
+	$SUDO ${PKG_MGR} ${INSTALL_COMMAND} ${PKG_NAMES} || exit_on_error
 
 	# Prepare Python virtual environment
 	if [ ! -d ".venv/bin" ]; then

--- a/install.sh
+++ b/install.sh
@@ -113,10 +113,10 @@ ask_pkg_mgr() {
 
 detect_sudo() {
 	# prefer `doas` if available
-	if type doas &>/dev/null; then
+	if command -v doas > /dev/null 2>&1; then
 		SUDO="doas"
 		echo "Using doas for installation"
-	elif type sudo &>/dev/null; then
+	elif command -v sudo > /dev/null 2>&1; then
 		SUDO="sudo"
 	else
 		return 1


### PR DESCRIPTION
This partially resolves #112 by allowing installing (but not running) pince on systems that do not have sudo (or simply prefer doas).

It should also be possible to add `run0` by adding another branch in the if at line 116. Since run0 uses polkit, this would support native installations for systems with polkit and without sudo. (ref. #177)

On my systems without sudo, due to polkit support, PINCE is entirely usable with this patch (ingoring the unsupported distro).